### PR TITLE
feat : 영화 평점 등록 및 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/opensource_server/review/domain/Review.java
+++ b/src/main/java/com/example/opensource_server/review/domain/Review.java
@@ -30,9 +30,8 @@ public class Review {
     @Column(name = "review_contents", nullable = false)
     private String reviewContents;
 
-    //영화 별점 추가
-    //@Column(nullable=false)
-    //private int score;  //별점은 정수로, 평균은 실수(소수점 2번째 자리까지)
+    @Column(nullable=false)
+    private int score;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "movie_id", nullable = false)

--- a/src/main/java/com/example/opensource_server/review/dto/request/ReviewCreateRequestDto.java
+++ b/src/main/java/com/example/opensource_server/review/dto/request/ReviewCreateRequestDto.java
@@ -12,4 +12,5 @@ import lombok.NoArgsConstructor;
 public class ReviewCreateRequestDto {
     private String nickname; // 리뷰 작성자 닉네임
     private String reviewContents; // 작성할 리뷰 내용
+    private int score;  //영화 별점
 }

--- a/src/main/java/com/example/opensource_server/review/dto/response/MovieReviewPageDto.java
+++ b/src/main/java/com/example/opensource_server/review/dto/response/MovieReviewPageDto.java
@@ -23,10 +23,19 @@ public class MovieReviewPageDto {
     private String director;    //감독
     private String movieRating; //등급(전체관람가,12세,..)
     private int reviewCount;    //리뷰 개수
+    private float avgScore; //평점 평균
     private List<String> thumbnails;    //썸네일(영화포스터)
     private List<ReviewDto> reviews;  //리뷰
 
     public static MovieReviewPageDto fromEntity(Movie movie, List<ReviewDto> reviewDtos) {
+        double averageScore = reviewDtos.stream()
+                .mapToInt(ReviewDto::getScore)
+                .average()
+                .orElse(0.0);
+
+        // 평균 점수는 소수점 둘째 자리까지만 계산
+        String formattedAvgScore = String.format("%.2f", averageScore);
+
         return MovieReviewPageDto.builder()
                 .title(movie.getTitle())
                 .releaseYear(movie.getReleaseYear())
@@ -37,6 +46,7 @@ public class MovieReviewPageDto {
                 .director(movie.getDirector())
                 .movieRating(movie.getMovieRating().name())
                 .reviewCount(reviewDtos.size())
+                .avgScore(Float.parseFloat(formattedAvgScore)) // 포맷된 문자열을 float로 변환
                 .thumbnails(
                         movie.getThumbnails().stream()
                                 .map(thumbnail -> thumbnail.getUrl())

--- a/src/main/java/com/example/opensource_server/review/dto/response/ReviewCreateResponseDto.java
+++ b/src/main/java/com/example/opensource_server/review/dto/response/ReviewCreateResponseDto.java
@@ -16,6 +16,7 @@ public class ReviewCreateResponseDto {//리뷰 작성 후 화면에 표시되는
     private LocalDateTime createdAt;
     private String nickname;
     private String reviewContents;
+    private int score;  //영화 별점
 
     // Review 엔티티를 ReviewCreateResponseDto로 변환
     public static ReviewCreateResponseDto fromEntity(Review review) {
@@ -23,6 +24,7 @@ public class ReviewCreateResponseDto {//리뷰 작성 후 화면에 표시되는
                 .createdAt(review.getCreatedAt())
                 .nickname(review.getNickname())
                 .reviewContents(review.getReviewContents())
+                .score(review.getScore())
                 .build();
     }
 }

--- a/src/main/java/com/example/opensource_server/review/dto/response/ReviewDto.java
+++ b/src/main/java/com/example/opensource_server/review/dto/response/ReviewDto.java
@@ -16,12 +16,14 @@ public class ReviewDto {    //리뷰 페이지 조회 시 보이는 리뷰 각�
     private String nickname;
     private String reviewContents;
     private LocalDateTime createdAt;
+    private int score;  //영화 별점
 
     public static ReviewDto fromEntity(Review review) {
         return ReviewDto.builder()
                 .nickname(review.getNickname())
                 .reviewContents(review.getReviewContents())
                 .createdAt(review.getCreatedAt())
+                .score(review.getScore())
                 .build();
     }
 }

--- a/src/main/java/com/example/opensource_server/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/example/opensource_server/review/service/ReviewServiceImpl.java
@@ -29,6 +29,7 @@ public class ReviewServiceImpl implements ReviewService{
                 .movie(movie)
                 .nickname(reviewCreateRequestDto.getNickname())
                 .reviewContents(reviewCreateRequestDto.getReviewContents())
+                .score(reviewCreateRequestDto.getScore())
                 .build();
         // 리뷰 객체 저장
         Review savedReview = reviewRepository.save(review);


### PR DESCRIPTION
#### 🏷️ feature/Issues#9
#### 📄 설명
사용자가 특정 영화 페이지에 접속하여 해당 영화에 대한 리뷰를 남길 때 평점(별점)을 등록할 수 있는 기능을 구현했습니다.
특정 영화 선택 시, 영화 세부 정보에 평균 평점을 소수점 2번째 자리까지 계산하여 조회할 수 있는 기능을 구현했습니다.
#### ✅ 작업 완료 내용
- [X] API Endpoint **`POST`** `/{movieId}/review/create`  (기존과 동일)
- [X] **`request`** 닉네임, 리뷰내용, **평점(int)** 입력
- [X] **`response`** 닉네임, 리뷰내용, 생성날짜, **영화 평점(int)** 반환

- [X] API Endpoint **`GET`** `/{movieId}/review` (기존과 동일)
- [X] **`response`** 영화제목, 개봉년도, 상영시간, 장르, 국가, 출연진, 감독, 등급, 리뷰 개수, **평균평점**, 썸네일(url), 리뷰(리스트) 반환